### PR TITLE
Temporary redirect support

### DIFF
--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -274,7 +274,7 @@ class RedirectManager:
         )
         return self._format(redirect_record)
 
-    def update(self, redirect_path, target_url):
+    def update(self, redirect_path, target_url, permanent=None):
         """
         Create or update redirect, by setting a target URL
         for a local URL path
@@ -286,6 +286,9 @@ class RedirectManager:
             "redirect_path": redirect_path,
             "target_url": target_url
         }
+
+        if permanent is not None:
+            data['permanent'] = permanent
 
         self.data_collection.update(search, data, True)
 
@@ -313,5 +316,6 @@ class RedirectManager:
         if redirect_record:
             return {
                 'redirect_path': redirect_record['redirect_path'],
+                'permanent': redirect_record.get('permanent', False),
                 'target_url': redirect_record['target_url']
             }


### PR DESCRIPTION
Up until now, all redirects have been permanent. This is a bad idea as permanent redirects are final. The default should be temporary, and permanent should be explicitly requested.

Also, temporary redirects gives us the option to change where the redirects point, so we can set unchanging URLs that will redirect to different permanently-cached assets.

QA
---

Get the server running:

``` bash
$ make setup develop
 * Running on http://0.0.0.0:8012/
```

In a new terminal, get a token:

``` bash
$ scripts/get-token.sh default
Token 'default' created
1234567890abcde1234567890abcde
```

Create a "normal" redirect:

``` bash
$ curl --data "redirect_path=a/file.jpg"  --data "target_url=/v1/xxxx-file.jpg"  "http://localhost:8012/v1/redirects?token=1234567890abcde1234567890abcde"
{
    "message": "Redirect created", 
    "target_url": "/v1/xxxx-file.jpg", 
    "redirect_path": "a/file.jpg"
}
```

Now check it's only a `302`:

``` bash
$ curl -I http://localhost:8012/a/file.jpg 
HTTP/1.0 302 FOUND
...
```

Now create a permanent redirect:

``` bash
$ curl --data "redirect_path=another/file.jpg"  --data "target_url=/v1/yyyy-file.jpg" --data "permanent=true" "http://localhost:8012/v1/redirects?token=121732f88a88490ea734923c4ef30ccd"
{
    "permanent": true, 
    "message": "Redirect created", 
    "target_url": "/v1/yyyy-file.jpg", 
    "redirect_path": "another/file.jpg"
}
```

Check it is a `301`:

``` bash
$ curl -I http://localhost:8012/another/file.jpg
HTTP/1.0 301 MOVED PERMANENTLY
...
```