### PR TITLE
Set headers for redirect responses as well

### DIFF
--- a/assets_server/lib/file_helpers.py
+++ b/assets_server/lib/file_helpers.py
@@ -1,6 +1,7 @@
 # System
 import errno
 import mimetypes
+import os
 import re
 
 # Packages
@@ -101,29 +102,20 @@ def remove_filename_hash(filename):
     return filename
 
 
-def get_mimetype(filename):
+def get_mimetype(filepath):
     """
     Get mimetype by file extension.
     If we have set an explicit mimetype, use that,
     otherwise ask Python to guess.
     """
 
-    extra_mappings = {
-        'woff2': 'font/woff2'
+    mappings = {
+        '.woff2': 'font/woff2'
     }
 
-    extension_match = re.search(r"(?<=\.)[^.]+$", filename)
+    extension = os.path.splitext(filepath)[1]
 
-    mime = None
-
-    if extension_match:
-        extension = extension_match.group(0)
-        mime = extra_mappings.get(extension)
-
-    if not mime:
-        mime = mimetypes.guess_type(filename)[0]
-
-    return mime
+    return mappings.get(extension) or mimetypes.guess_type(filepath)[0]
 
 
 def file_error(error_number, message, filename):

--- a/assets_server/lib/http_helpers.py
+++ b/assets_server/lib/http_helpers.py
@@ -99,12 +99,15 @@ def error_response(error, file_path=''):
     )
 
 
-def set_headers_for_type(response):
+def set_headers_for_type(response, content_type=None):
     """
     Setup all requires response headers appropriate for this file
     """
 
-    if "font" in response["Content-Type"]:
+    if not content_type:
+        content_type = response["Content-Type"]
+
+    if "font" in content_type:
         response['Access-Control-Allow-Origin'] = '*'
 
     return response

--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -1,9 +1,9 @@
 # System
+import errno
+import re
 from base64 import b64decode
 from datetime import datetime
 from urllib import unquote
-import errno
-import re
 
 # Packages
 from django.conf import settings
@@ -431,4 +431,6 @@ class Redirects(APIView):
         if not redirect_record:
             return error_404(request.path)
 
-        return HttpResponsePermanentRedirect(redirect_record['target_url'])
+        response = HttpResponsePermanentRedirect(redirect_record['target_url'])
+
+        return set_headers_for_type(response, get_mimetype(request_path))


### PR DESCRIPTION
Specifically, this is because we need the `Access-Control-Allow-Origin: *` header
when redirecting fonts, so that sites can still link to the old font URLs without breaking.

Fixes #84.

QA
---

Get the server running (you may need to download your canonistack credentials):

``` bash
$ source ~/.canonistack/novarc  # source your canonistack credentials, for swift
$ make setup develop
 * Running on http://0.0.0.0:8012/
```

In a new terminal, upload a font file:

``` bash
$ wget -O font.woff https://assets.ubuntu.com/v1/8df3f408-ubuntumono-r-webfont.woff
$ source ~/.canonistack/novarc  # source your canonistack credentials, for swift
$ scripts/upload-asset.sh font.woff  # Upload font
{'optimized': False, 'created': 'Tue Nov  1 22:20:42 2016', 'file_path': u'8df3f408-font.woff', 'tags': ''}
```

Get a token:

``` bash
$ scripts/get-token.sh default
Token 'default' created
1234567890abcde1234567890abcde
```

Create a redirect to the font:

``` bash
$ curl --data "redirect_path=font.woff"  --data "target_url=/v1/8df3f408-font.woff"  "http://localhost:8012/v1/redirects?token=1234567890abcde1234567890abcde"
{
    "message": "Redirect created", 
    "target_url": "/v1/8df3f408-font.woff", 
    "redirect_path": "font.woff"
}
```

Now check that both the original file and the redirect return `Access-Control-Allow-Origin: *`:

``` bash
$ curl -I http://localhost:8012/font.woff
HTTP/1.0 301 MOVED PERMANENTLY
Access-Control-Allow-Origin: *
...

$ curl -I http://localhost:8012/v1/8df3f408-font.woff
HTTP/1.0 200 OK
...
Access-Control-Allow-Origin: *
```

Now check that you can successfully make use of a font via its redirect:

``` bash
$ echo '<style>@font-face {font-family: "Ubuntu"; src: url("http://127.0.0.1:8012/font.woff");}</style>' > font-test.html
$ echo '<h1 style="font-family: Ubuntu">Hello world</h1>' >> font-test.html
$ xdg-open font-test.html
```

Check "Hello world" is in the ubuntu font, and open the console and check there are no "blocked" errors.
