### PR TITLE
Temporary redirect support

### DIFF
--- a/assets_server/mappers.py
+++ b/assets_server/mappers.py
@@ -297,7 +297,7 @@ class RedirectManager:
         )
         return self._format(redirect_record)
 
-    def update(self, redirect_path, target_url):
+    def update(self, redirect_path, target_url, permanent=None):
         """
         Create or update redirect, by setting a target URL
         for a local URL path
@@ -309,6 +309,9 @@ class RedirectManager:
             "redirect_path": redirect_path,
             "target_url": target_url
         }
+
+        if permanent is not None:
+            data['permanent'] = permanent
 
         self.data_collection.update(search, data, True)
 
@@ -336,5 +339,6 @@ class RedirectManager:
         if redirect_record:
             return {
                 'redirect_path': redirect_record['redirect_path'],
+                'permanent': redirect_record.get('permanent', False),
                 'target_url': redirect_record['target_url']
             }

--- a/assets_server/views.py
+++ b/assets_server/views.py
@@ -7,9 +7,8 @@ from urllib import unquote
 
 # Packages
 from django.conf import settings
-from django.http import (
-    HttpResponse, HttpResponseNotModified, HttpResponsePermanentRedirect
-)
+from django.http import HttpResponse, HttpResponseNotModified
+from django.shortcuts import redirect
 from pilbox.errors import PilboxError
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
@@ -313,13 +312,17 @@ class RedirectRecords(APIView):
 
         redirect_path = request.DATA.get('redirect_path').lstrip('/')
         target_url = request.DATA.get('target_url')
+        permanent = request.DATA.get(
+            'permanent', 'false'
+        ).lower() in ('true', 'yes', 'on')
 
         # Remove multiple-slashes
         redirect_path = re.sub("//+", "/", redirect_path)
 
         body = {
             'redirect_path': redirect_path,
-            'target_url': target_url
+            'target_url': target_url,
+            'permanent': permanent
         }
 
         redirect_record = False
@@ -346,7 +349,8 @@ class RedirectRecords(APIView):
         else:
             redirect_record = settings.REDIRECT_MANAGER.update(
                 redirect_path,
-                target_url
+                target_url,
+                permanent
             )
 
             if redirect_record:
@@ -385,13 +389,12 @@ class RedirectRecord(APIView):
 
         target_url = request.DATA.get('target_url')
 
-        if not target_url:
-            raise ParseError((
-                'To update a redirect, '
-                'please supply a target_url'
-            ))
+        if not settings.REDIRECT_MANAGER.exists(redirect_path):
+            return error_404(request.path)
 
-        if target_url:
+        if not target_url:
+            raise ParseError('To update a redirect, supply a target_url')
+        else:
             redirect_record = settings.REDIRECT_MANAGER.update(
                 unquote(redirect_path),
                 target_url
@@ -418,7 +421,7 @@ class RedirectRecord(APIView):
 
 class Redirects(APIView):
     """
-    Do 301 redirect for any redirects found in the MongoDB
+    Do redirect for any redirects found in the MongoDB
     """
 
     def get(self, request, request_path):
@@ -430,6 +433,9 @@ class Redirects(APIView):
         if not redirect_record:
             return error_404(request.path)
 
-        response = HttpResponsePermanentRedirect(redirect_record['target_url'])
+        response = redirect(
+            redirect_record['target_url'],
+            permanent=redirect_record.get('permanent', False)
+        )
 
         return set_headers_for_type(response, get_mimetype(request_path))


### PR DESCRIPTION
Up until now, all redirects have been permanent. This is a bad idea as permanent redirects are final. The default should be temporary, and permanent should be explicitly requested.

Also, temporary redirects gives us the option to change where the redirects point, so we can set unchanging URLs that will redirect to different permanently-cached assets.

QA
---

Get the server running:

``` bash
$ make setup develop
 * Running on http://0.0.0.0:8012/
```

In a new terminal, get a token:

``` bash
$ scripts/get-token.sh default
Token 'default' created
1234567890abcde1234567890abcde
```

Create a "normal" redirect:

``` bash
$ curl --data "redirect_path=a/file.jpg"  --data "target_url=/v1/xxxx-file.jpg"  "http://localhost:8012/v1/redirects?token=1234567890abcde1234567890abcde"
{
    "message": "Redirect created", 
    "target_url": "/v1/xxxx-file.jpg", 
    "redirect_path": "a/file.jpg"
}
```

Now check it's only a `302`:

``` bash
$ curl -I http://localhost:8012/a/file.jpg 
HTTP/1.0 302 FOUND
...
```

Now create a permanent redirect:

``` bash
$ curl --data "redirect_path=another/file.jpg"  --data "target_url=/v1/yyyy-file.jpg" --data "permanent=true" "http://localhost:8012/v1/redirects?token=121732f88a88490ea734923c4ef30ccd"
{
    "permanent": true, 
    "message": "Redirect created", 
    "target_url": "/v1/yyyy-file.jpg", 
    "redirect_path": "another/file.jpg"
}
```

Check it is a `301`:

``` bash
$ curl -I http://localhost:8012/another/file.jpg
HTTP/1.0 301 MOVED PERMANENTLY
...
```