### PR TITLE
Add support for multiple operations and supporting README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,32 @@ The server is intended to be run in production behind a caching layer (e.g. [squ
 Using the server
 ---
 
+### Transforming images
+
+Images can be transformed using the `op` get option, along with the required arguments.
+
+You can manually specify one of these operations along with their corresponding options:
+ - `region`
+  - `rect`: The region as x,y,w,h; x,y: top-left position, w,h: width/height of region
+ - `resize`
+  - `w`: Width
+  - `h`: Height
+  - `max-width`
+  - `max-height`
+ - `rotate`
+  - `deg`: Degrees to rotate the image
+
+The default option is resize and can be used without setting `op`
+```
+14e45f53-image.png?w=30
+```
+
+You can also specify multiple comma separated operations. They will be applied in the order they are listed.
+```
+14e45f53-image.png?op=region,resize&w=30&rect=0,0,50,50
+```
+
+
 ### Tokens
 
 To interact with the assets server, you'll need to generate an authentication token:

--- a/assets_server/lib/processors.py
+++ b/assets_server/lib/processors.py
@@ -3,6 +3,7 @@ from io import BytesIO
 import os
 
 # Modules
+from more_itertools import unique_everseen
 from pilbox.errors import PilboxError
 from pilbox.image import Image as PilboxImage
 from scour.scour import scourString
@@ -112,6 +113,8 @@ class ImageProcessor:
                 operation = "resize"
 
             operations = operation.split(',')
+            # Remove duplicate operations from list
+            operations = unique_everseen(operations)
 
             for operation in operations:
                 if operation or 'q' in self.options:

--- a/assets_server/lib/processors.py
+++ b/assets_server/lib/processors.py
@@ -111,12 +111,16 @@ class ImageProcessor:
             ):
                 operation = "resize"
 
-            if operation or 'q' in self.options:
-                try:
-                    self._pilbox_operation(operation)
-                except (TypeError, AttributeError) as operation_error:
-                    self._missing_param_error(operation_error, operation)
+            operations = operation.split(',')
 
+            for operation in operations:
+                if operation or 'q' in self.options:
+                    try:
+                        self._pilbox_operation(operation)
+                    except (TypeError, AttributeError) as operation_error:
+                        self._missing_param_error(operation_error, operation)
+
+            if operation:
                 return True
 
     # Private helper methods

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -8,6 +8,7 @@ iso8601==0.1.10
 itsdangerous==0.24
 Jinja2==2.7.2
 MarkupSafe==0.21
+more-itertools==2.5.0
 netaddr==0.7.11
 pilbox==0.9.18
 prettytable==0.7.2


### PR DESCRIPTION
Add support to process multiple operations via a comma separated `op` value.

For example, crop and then resize the image:
`14e45f53-image.png?op=region,resize&w=30&rect=0,0,50,50`

I also added some information about the options in the readme.

This fixes #64 


## QA

I recommend running mongo through Docker with:
```
docker run -p 27017:27017 -p 28017:28017 mongo
```

Then following the make commands:
```
make setup    # Install dependencies <-- This installs mongo, I recommend removing mongo from makefile
make develop  # Run development server on port 8012
```

Upload an image following instructions form README.md

Check multiple options on an uploaded image, as with image url from top of this description.